### PR TITLE
Ensure RN flavour is transpiled with babel.

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,1 +1,1 @@
-module.exports = require('./src/android/index');
+module.exports = require('./dist/android/index');

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,1 +1,1 @@
-module.exports = require('./src/ios/index');
+module.exports = require('./dist/ios/index');

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 // Export web by default. Other platforms have custom index.[platform].js files
-module.exports = require('./dist/index');
+module.exports = require('./dist/web/index');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:setup": "npm i && node ./node_modules/.bin/npm-install-peers",
     "dev:android": "react-native run-android",
     "dev:ios": "react-native run-ios",
-    "build": "babel src/web/index.js --out-file dist/index.js",
+    "build": "babel src --out-dir dist --source-maps",
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook-native": "storybook start -p 7007 --haul ./.storybook/native/webpack.haul.storybook.js --platform all",
     "storybook-web": "start-storybook -p 6006 -c ./.storybook/web",
@@ -19,7 +19,6 @@
     "README.md",
     "./index.js",
     "dist/",
-    "src/",
     "index.ios.js",
     "index.android.js"
   ],
@@ -32,7 +31,6 @@
   "dependencies": {
     "bodymovin": "^4.13.0",
     "lottie-react-native": "^2.2.7",
-    "lottie-web": "^5.0.4",
     "prop-types": "^15.5.9"
   },
   "peerDependencies": {


### PR DESCRIPTION
- change babel build to output preserved directory structure
- remove depend on lottie-web as bodymovin is used directly instead
- change RN ios and android files to reference dist not src.
- remove "src" from distribution as its no longer needed.

Issue #11